### PR TITLE
pkg: Do not start asterisk if no DNS

### DIFF
--- a/debian/asterisk.service
+++ b/debian/asterisk.service
@@ -6,6 +6,7 @@ After=network.target
 User=root
 LimitCORE=infinity
 LimitNOFILE=65535
+ExecStartPre=/usr/bin/getent hosts trunks.ivozprovider.local
 ExecStart=/usr/sbin/asterisk -f -C /etc/asterisk/asterisk.conf
 ExecStop=/usr/sbin/asterisk -rx 'core stop now'
 ExecReload=/usr/sbin/asterisk -rx 'core reload'


### PR DESCRIPTION
Starting asterisk without name resolution capabilities leads to inconsistent state:

- match 'ip' for trunks.ivozprovider.local fails.

- INVITEs from trunks are not recognized.

- No inbound external calls for all calls handled by AS.

This PR tries to prevent this problem making asterisk start fail (dispatcher module will discard AS as soon as it doesn't respond).