### PR TITLE
patch: create MWI subscriptions even when initial notify is disabled

### DIFF
--- a/debian/patches/018_initial_mwi_subscriptions.patch
+++ b/debian/patches/018_initial_mwi_subscriptions.patch
@@ -1,0 +1,16 @@
+diff --git a/res/res_pjsip_mwi.c b/res/res_pjsip_mwi.c
+index dfe5481f334..8c02573e226 100644
+--- a/res/res_pjsip_mwi.c
++++ b/res/res_pjsip_mwi.c
+@@ -1599,8 +1599,10 @@ static int load_module(void)
+ 	ast_sorcery_observer_add(ast_sip_get_sorcery(), "global", &global_observer);
+ 	ast_sorcery_reload_object(ast_sip_get_sorcery(), "global");
+ 
++	// Create subscriptions even when initial unsolicited MWI is disabled
++	create_mwi_subscriptions();
++
+ 	if (!ast_sip_get_mwi_disable_initial_unsolicited()) {
+-		create_mwi_subscriptions();
+ 		if (ast_test_flag(&ast_options, AST_OPT_FLAG_FULLY_BOOTED)) {
+ 			ast_sip_push_task(ast_serializer_pool_get(mwi_serializer_pool),
+ 				send_initial_notify_all, NULL);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,3 +14,4 @@
 015_agi_log_colors.patch
 016_manager_originate_extension_vars.patch
 017_max_hint_watchers.patch
+018_initial_mwi_subscriptions.patch


### PR DESCRIPTION
Create MWI subscriptions on startup even when mwi_disable_initial_unsolicited is enabled